### PR TITLE
Added displaying recently ordered meals

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -818,7 +818,8 @@ class Home extends React.Component {
                                 
 
 
-                                <Sliders showRecipe={this.handleGetRecipe} callback={this.addToCart} log={this.state.loggedIn} setVisible={this.setVisibleR} recipe1={this.state.category1} recipe2={this.state.category2} recipe3={this.state.category3} />
+                                <Sliders showRecipe={this.handleGetRecipe} callback={this.addToCart} log={this.state.loggedIn} setVisible={this.setVisibleR} 
+                                    recipe1={this.state.category1} recipe2={this.state.category2} recipe3={this.state.category3} previouslyOrdered ={this.state.history} isSignedIn={this.state.loggedIn}/>
                                 {/*<RecipeSearch callback={this.addToCart} recipes={recipes.results1.concat(recipes.results2.concat(recipes.results3))} />*/}
                                 <RecipeSearch setVisible={this.setVisibleR} log={this.state.loggedIn} callback={this.addToCart}/>
                                 <Footer />

--- a/client/src/components/Sliders.js
+++ b/client/src/components/Sliders.js
@@ -3,6 +3,22 @@ import SliderRecipe from './SliderRecipe'
 import RecipeSearch from "./Search.js"
 
 
+function RecenltyOrdered(props){
+    if(!props.show){
+        return null;
+    }
+
+    return (
+        <div>
+            <h3 style={{ marginTop: '10px', marginLeft: '50px', marginBottom: '10px', fontWeight: '600' }}> Recently Ordered</h3>
+            <div className="margin-bottom-60">
+                <SliderRecipe showRecipe={props.showRecipe} log={props.log} callback={props.callback} setVisible={props.setVisible} list={props.list} />
+            </div>
+        </div>
+
+    );
+}
+
 export class Sliders extends Component {
 constructor(props){
     super(props);
@@ -45,8 +61,8 @@ onComponentMount(){
                                 <div className="margin-bottom-60">
                                     <SliderRecipe showRecipe={this.props.showRecipe} log={this.props.log} callback={this.props.callback} setVisible={this.props.setVisible} list={this.props.recipe3} />
                                 </div>
-
-                                
+                                <RecenltyOrdered showRecipe ={this.props.showRecipe} log={this.props.log} callback={this.props.callback} setVisible={this.props.setVisible} 
+                                    list={this.props.previouslyOrdered} show={this.props.isSignedIn}/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
I added another slider with recently purchased items. It was pretty simple since we already were storing the history - just when I tried to implement it last weekend the sliders were statically rendered but now that they get rendered with props it was much easier.

I noticed that if a slider has two or one entities in it - they render weirdly and stack a duplicate row right under the row we want. This was probably overlooked before since the other sliders will never have under three entities but with user history it is highly likely that a user could have only 1 or 2 entities here so this should be looked into and solved. 

Also, I'm not sure where the dividing lines between sliders is getting added from, but presumably we would need one to separate before the order history slider now. Might have to add that to the `RecentlyOrdered` function so it only renders when there is a user logged in as well.
